### PR TITLE
Extend smtp_pass field to 128 characters

### DIFF
--- a/odoo/addons/base/ir/ir_mail_server.py
+++ b/odoo/addons/base/ir/ir_mail_server.py
@@ -143,7 +143,7 @@ class IrMailServer(models.Model):
     smtp_host = fields.Char(string='SMTP Server', required=True, help="Hostname or IP of SMTP server")
     smtp_port = fields.Integer(string='SMTP Port', size=5, required=True, default=25, help="SMTP Port. Usually 465 for SSL, and 25 or 587 for other cases.")
     smtp_user = fields.Char(string='Username', size=64, help="Optional username for SMTP authentication")
-    smtp_pass = fields.Char(string='Password', size=64, help="Optional password for SMTP authentication")
+    smtp_pass = fields.Char(string='Password', size=128, help="Optional password for SMTP authentication")
     smtp_encryption = fields.Selection([('none', 'None'),
                                         ('starttls', 'TLS (STARTTLS)'),
                                         ('ssl', 'SSL/TLS')],


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Extend smtp_pass field to 128 characters as Sendgrid API keys are longer than 64 characters.

Current behavior before PR:
Cannot authenticate with Sendgrid SMTP server due to truncated password.

Desired behavior after PR is merged:
Authentication with Sendgrid SMTP server works.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
