### PR TITLE
misc changes

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -114,7 +114,8 @@ def dispatch_rpc(service_name, method, params):
             if psutil:
                 start_memory = memory_info(psutil.Process(os.getpid()))
             if rpc_request and rpc_response_flag:
-                odoo.netsvc.log(rpc_request, logging.DEBUG, '%s.%s' % (service_name, method), replace_request_password(params))
+                # [TPM] odoo.netsvc.log(rpc_request, logging.DEBUG, '%s.%s' % (service_name, method), replace_request_password(params))
+                odoo.netsvc.log(rpc_request, logging.DEBUG, '%s.%s' % (service_name, method))
 
         threading.current_thread().uid = None
         threading.current_thread().dbname = None
@@ -133,7 +134,8 @@ def dispatch_rpc(service_name, method, params):
                 end_memory = memory_info(psutil.Process(os.getpid()))
             logline = '%s.%s time:%.3fs mem: %sk -> %sk (diff: %sk)' % (service_name, method, end_time - start_time, start_memory / 1024, end_memory / 1024, (end_memory - start_memory)/1024)
             if rpc_response_flag:
-                odoo.netsvc.log(rpc_response, logging.DEBUG, logline, result)
+                # [TPM] odoo.netsvc.log(rpc_response, logging.DEBUG, logline, result)
+                odoo.netsvc.log(rpc_response, logging.DEBUG, logline)
             else:
                 odoo.netsvc.log(rpc_request, logging.DEBUG, logline, replace_request_password(params), depth=1)
 
@@ -699,8 +701,10 @@ class JsonRequest(WebRequest):
                 if psutil:
                     start_memory = memory_info(psutil.Process(os.getpid()))
                 if rpc_request and rpc_response_flag:
-                    rpc_request.debug('%s: %s %s, %s',
-                        endpoint, model, method, pprint.pformat(args))
+                    # [TPM] rpc_request.debug('%s: %s %s, %s',
+                    #     endpoint, model, method, pprint.pformat(args))
+                    rpc_request.debug('%s: %s %s',
+                        endpoint, model, method)
 
             result = self._call_function(**self.params)
 
@@ -712,7 +716,8 @@ class JsonRequest(WebRequest):
                 logline = '%s: %s %s: time:%.3fs mem: %sk -> %sk (diff: %sk)' % (
                     endpoint, model, method, end_time - start_time, start_memory / 1024, end_memory / 1024, (end_memory - start_memory)/1024)
                 if rpc_response_flag:
-                    rpc_response.debug('%s, %s', logline, pprint.pformat(result))
+                    # [TPM] rpc_response.debug('%s, %s', logline, pprint.pformat(result))
+                    rpc_response.debug('%s', logline)
                 else:
                     rpc_request.debug(logline)
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -527,7 +527,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
             if not getattr(base, 'pool', None):
                 # the following attributes are not taken from model classes
                 if not base._inherit and not base._description:
-                    _logger.warning("The model %s has no _description", cls._name)
+                    _logger.debug("The model %s has no _description", cls._name) #TPM
                 cls._description = base._description or cls._description
                 cls._table = base._table or cls._table
                 cls._sequence = base._sequence or cls._sequence

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -135,7 +135,7 @@ class Cursor(object):
             *any* data which may be modified during the life of the cursor.
 
     """
-    IN_MAX = 1000   # decent limit on size of IN queries - guideline = Oracle limit
+    IN_MAX = 500 # 1000   # decent limit on size of IN queries - guideline = Oracle limit
 
     def check(f):
         @wraps(f)


### PR DESCRIPTION
- update log level to debug when a model does not have description
- set the max items in a SQL IN clause from 1000 to 500. when the model is project_task, memory consumption is very high even with 1000 rows since the table is very wide.
- The performance metrics for rpc request and response including for cron workers can be nice to know but it included the request and response payload that is very verbose and could have log performance implications. Till a better solution is found, removed the payloads from the logs.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
